### PR TITLE
allow ember-concurrency 0.8.x & 0.9.x & 0.10.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "qunit-dom": "^0.7.1"
   },
   "peerDependencies": {
-    "ember-concurrency": "^0.8.21"
+    "ember-concurrency": "^0.8.27 || ^0.9.0 || ^0.10.0"
   },
   "engines": {
     "node": "6.* || 8.* || >= 10.*"


### PR DESCRIPTION
Since we don't really care about which ember-concurrency version people are using, we can relax the peer dependency.
The api between all of these versions is the same, so it should still work as expected.
For reference, this was what ember-power-select did.