### PR TITLE
Don't run polling task in tests

### DIFF
--- a/addon/services/service-worker-update-notify.js
+++ b/addon/services/service-worker-update-notify.js
@@ -9,16 +9,12 @@ import serviceWorkerHasUpdate from '../utils/service-worker-has-update'
 const configKey = 'ember-service-worker-update-notify'
 
 async function update() {
-  if (Ember.testing) {
-    return;
-  }
-
   const reg = await navigator.serviceWorker.register(
     '{{ROOT_URL}}{{SERVICE_WORKER_FILENAME}}',
     { scope: '{{ROOT_URL}}' },
   );
 
-  reg.update();
+  return reg.update();
 }
 
 export default Service.extend(Evented, {
@@ -53,7 +49,9 @@ export default Service.extend(Evented, {
     this._super(...arguments);
     if (typeof FastBoot === 'undefined') {
       this._attachUpdateHandler();
-      this.pollingTask.perform();
+      if (!Ember.testing) {
+        this.pollingTask.perform();
+      }
     }
   }
 });

--- a/tests/acceptance/usage-test.js
+++ b/tests/acceptance/usage-test.js
@@ -34,10 +34,8 @@ module('Acceptance | usage', function(hooks) {
   module('with setup', function(hooks) {
     setupServiceWorkerUpdater(hooks);
 
-    hooks.beforeEach(function() {
-      // don't await, because the concurrency tasks
-      // will block settledState from occurring.
-      visit('/');
+    hooks.beforeEach(async function() {
+      await visit('/');
     });
 
     hooks.afterEach(async function() {


### PR DESCRIPTION
Prevent settledness in tests never occurring due to the busy polling task.

Fixes #22