### PR TITLE
Guard against navigator.serviceWorker being undefined

### DIFF
--- a/addon/services/service-worker-update-notify.js
+++ b/addon/services/service-worker-update-notify.js
@@ -6,7 +6,8 @@ import { computed } from '@ember/object';
 import { task, timeout } from 'ember-concurrency'
 import serviceWorkerHasUpdate from '../utils/service-worker-has-update'
 
-const configKey = 'ember-service-worker-update-notify'
+const configKey = 'ember-service-worker-update-notify';
+const supportsServiceWorker = typeof navigator !== 'undefined' && 'serviceWorker' in navigator;
 
 async function update() {
   const reg = await navigator.serviceWorker.register(
@@ -49,7 +50,7 @@ export default Service.extend(Evented, {
     this._super(...arguments);
     if (typeof FastBoot === 'undefined') {
       this._attachUpdateHandler();
-      if (!Ember.testing) {
+      if (!Ember.testing && supportsServiceWorker) {
         this.pollingTask.perform();
       }
     }


### PR DESCRIPTION
Seeing a lot of `TypeError: navigator.serviceWorker is undefined` in production, the current code does not properly guard against `navigator.serviceWorker` being undefined. Which is the case for browsers not supporting SW, but also for Firefox in private browsing mode!