### PR TITLE
Guard against exceptions when calling navigator.serviceWorker.register()

### DIFF
--- a/addon/services/service-worker-update-notify.js
+++ b/addon/services/service-worker-update-notify.js
@@ -10,12 +10,18 @@ const configKey = 'ember-service-worker-update-notify';
 const supportsServiceWorker = typeof navigator !== 'undefined' && 'serviceWorker' in navigator;
 
 async function update() {
-  const reg = await navigator.serviceWorker.register(
-    '{{ROOT_URL}}{{SERVICE_WORKER_FILENAME}}',
-    { scope: '{{ROOT_URL}}' },
-  );
+  try {
+    // FF will throw an `SecurityError: The operation is insecure.` error here when cookies are disabled/restricted.
+    // So guard in a try/catch
+    const reg = await navigator.serviceWorker.register(
+      '{{ROOT_URL}}{{SERVICE_WORKER_FILENAME}}',
+      { scope: '{{ROOT_URL}}' },
+    )
 
-  return reg.update();
+    return reg.update()
+  } catch(e) {
+    console.error(e);
+  }
 }
 
 export default Service.extend(Evented, {


### PR DESCRIPTION
Firefox seems to follow a policy that `navigator.serviceWorker.register()` is blocked when cookies are disabled. Due to that we see quite a few `SecurityError: The operation is insecure.` errors in our Sentry logs.

This change will just wrap the code in a try/catch, as I believe when the update function does not work for whatever reason, this should not be treated as an application-wide hard error, so rather be catched and not propagate up.